### PR TITLE
Atualizado a versão na referência do Newtonsoft.Json

### DIFF
--- a/PontoWebIntegracaoExterna.csproj
+++ b/PontoWebIntegracaoExterna.csproj
@@ -34,8 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
O erro de não encontrar a referência para `Newtonsoft.Json` na hora de rodar o projeto ocorria pois a versão que estava referenciada no `PontoWebIntegracaoExterna.csproj` era a versão 11.0.1 e foi alterado para a mesma versão do pacote nuGet, que é a versão 13.0.1.
Após isso o erro parou de ocorrer.